### PR TITLE
Fix blocking issues

### DIFF
--- a/HybridManagement/HybridManagement.psd1
+++ b/HybridManagement/HybridManagement.psd1
@@ -90,7 +90,8 @@
         "Compress-AzResourceId",
         "Get-AzCurrentAzureADUser",
         "Test-AzPermission",
-        "Assert-AzPermission"
+        "Assert-AzPermission",
+        "Get-RandomString"
     
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport = @()

--- a/HybridManagement/HybridManagement.psd1
+++ b/HybridManagement/HybridManagement.psd1
@@ -84,7 +84,7 @@
         "Get-AzStorageKerberosTicketStatus",
         "Test-AzStorageAccountADObjectPasswordIsKerbKey",
         "Update-AzStorageAccountADObjectPassword",
-        "Join-AzStorageAccountForAuth", 
+        "Join-AzStorageAccount", 
         "Invoke-AzStorageAccountADObjectPasswordRotation",
         "Expand-AzResourceId",
         "Compress-AzResourceId",
@@ -100,7 +100,7 @@
     VariablesToExport = '*'
     
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-    AliasesToExport = @()
+    AliasesToExport = "*"
     
     # DSC resources to export from this module
     # DscResourcesToExport = @()

--- a/HybridManagement/HybridManagement.psm1
+++ b/HybridManagement/HybridManagement.psm1
@@ -827,16 +827,21 @@ function Request-AzPowerShellModule {
                     -RequiredVersion "1.11.1-preview" `
                     -SkipPublisherCheck `
                     -ErrorAction Stop
-                
-                Import-Module -Name Az.Storage -RequiredVersion "1.11.1"
-            } else {
-                Import-Module -ModuleInfo $storageModule
-            }            
+            }       
         }
     }
     
     Remove-Module -Name PowerShellGet -ErrorAction SilentlyContinue
     Remove-Module -Name PackageManagement -ErrorAction SilentlyContinue
+
+    $storageModule = Get-Module -Name Az.Storage -ListAvailable | `
+        Where-Object { 
+            $_.Version -eq [Version]::new(1,8,2) -or 
+            $_.Version -eq [Version]::new(1,11,1) 
+        } | `
+        Sort-Object -Property Version -Descending
+    
+    Import-Module -ModuleInfo $storageModule[0] -Global -ErrorAction Stop
 }
 
 function Validate-StorageAccount {

--- a/HybridManagement/HybridManagement.psm1
+++ b/HybridManagement/HybridManagement.psm1
@@ -871,7 +871,7 @@ function New-ADAccountForStorageAccount {
 
         [Parameter(Mandatory=$false, Position=5)]
         [ValidateSet("ServiceLogonAccount", "ComputerAccount")]
-        [string]$ObjectType = "ServiceLogonAccount"
+        [string]$ObjectType = "ComputerAccount"
     )
 
     Assert-IsWindows
@@ -1883,7 +1883,7 @@ function Join-AzStorageAccountForAuth {
 
         [Parameter(Mandatory=$false, Position=3)]
         [ValidateSet("ServiceLogonAccount", "ComputerAccount")]
-        [string]$DomainAccountType = "ServiceLogonAccount",
+        [string]$DomainAccountType = "ComputerAccount",
 
         [Parameter(Mandatory=$false, Position=4)]
         [string]$OrganizationalUnitName,

--- a/HybridManagement/HybridManagement.psm1
+++ b/HybridManagement/HybridManagement.psm1
@@ -671,7 +671,10 @@ function Request-ADFeature {
             -WindowsServerFeature "RSAT-AD-PowerShell"
     }
 
-    Import-Module -Name ActiveDirectory
+    $adModule = Get-Module -Name ActiveDirectory 
+    if ($null -eq $adModule) {
+        Import-Module -Name ActiveDirectory
+    }
 }
 
 function Validate-StorageAccount {
@@ -1309,12 +1312,15 @@ function Set-StorageAccountDomainProperties {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true, Position=0)]
-        [string]$ResourceGroupName,
+        [string]$ADObjectName,
 
         [Parameter(Mandatory=$true, Position=1)]
+        [string]$ResourceGroupName,
+
+        [Parameter(Mandatory=$true, Position=2)]
         [string]$StorageAccountName,
 
-        [Parameter(Mandatory=$false, Position=2)]
+        [Parameter(Mandatory=$false, Position=3)]
         [string]$Domain
     )
 
@@ -1332,7 +1338,7 @@ function Set-StorageAccountDomainProperties {
     }
 
     $azureStorageIdentity = Get-AzStorageAccountADObject `
-        -ADObjectName $StorageAccountName `
+        -ADObjectName $ADObjectName `
         -Domain $Domain `
         -ErrorAction Stop
     $azureStorageSid = $azureStorageIdentity.SID.Value
@@ -1932,6 +1938,7 @@ function Join-AzStorageAccountForAuth {
 
             # Create the service account object for the storage account.
             New-ADAccountForStorageAccount `
+                -ADObjectName $ADObjectNameOverride `
                 -StorageAccountName $StorageAccountName `
                 -ResourceGroupName $ResourceGroupName `
                 -Domain $Domain `
@@ -1941,6 +1948,7 @@ function Join-AzStorageAccountForAuth {
 
             # Set domain properties on the storage account.
             Set-StorageAccountDomainProperties `
+                -ADObjectName $ADObjectNameOverride `
                 -ResourceGroupName $ResourceGroupName `
                 -StorageAccountName $StorageAccountName `
                 -Domain $Domain

--- a/HybridManagement/HybridManagement.psm1
+++ b/HybridManagement/HybridManagement.psm1
@@ -1986,7 +1986,7 @@ function Invoke-AzStorageAccountADObjectPasswordRotation {
     }
 }
 
-function Join-AzStorageAccountForAuth {
+function Join-AzStorageAccount {
     <#
     .SYNOPSIS 
     Domain join a storage account to an Active Directory Domain Controller.
@@ -2027,18 +2027,18 @@ function Join-AzStorageAccountForAuth {
     arbitrary name. This does not affect how you access your storage account.
 
     .EXAMPLE
-    PS> Join-AzStorageAccountForAuth -ResourceGroupName "myResourceGroup" -StorageAccountName "myStorageAccount" -Domain "subsidiary.corp.contoso.com" -DomainAccountType ComputerAccount -OrganizationalUnitName "StorageAccountsOU"
+    PS> Join-AzStorageAccount -ResourceGroupName "myResourceGroup" -StorageAccountName "myStorageAccount" -Domain "subsidiary.corp.contoso.com" -DomainAccountType ComputerAccount -OrganizationalUnitName "StorageAccountsOU"
 
     .EXAMPLE 
     PS> $storageAccount = Get-AzStorageAccount -ResourceGroupName "myResourceGroup" -Name "myStorageAccount"
-    PS> Join-AzStorageAccountForAuth -StorageAccount $storageAccount -Domain "subsidiary.corp.contoso.com" -DomainAccountType ComputerAccount -OrganizationalUnitName "StorageAccountsOU"
+    PS> Join-AzStorageAccount -StorageAccount $storageAccount -Domain "subsidiary.corp.contoso.com" -DomainAccountType ComputerAccount -OrganizationalUnitName "StorageAccountsOU"
 
     .EXAMPLE
-    PS> Get-AzStorageAccount -ResourceGroupName "myResourceGroup" | Join-AzStorageAccountForAuth -Domain "subsidiary.corp.contoso.com" -DomainAccountType ComputerAccount -OrganizationalUnitName "StorageAccountsOU"
+    PS> Get-AzStorageAccount -ResourceGroupName "myResourceGroup" | Join-AzStorageAccount -Domain "subsidiary.corp.contoso.com" -DomainAccountType ComputerAccount -OrganizationalUnitName "StorageAccountsOU"
 
     In this example, note that a specific storage account has not been specified to 
     Get-AzStorageAccount. This means Get-AzStorageAccount will pipe every storage account 
-    in the resource group myResourceGroup to Join-AzStorageAccountForAuth.
+    in the resource group myResourceGroup to Join-AzStorageAccount.
     #>
 
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact="Medium")]
@@ -2156,6 +2156,8 @@ function Join-AzStorageAccountForAuth {
     }
 }
 
+# Add alias for Join-AzStorageAccountForAuth
+New-Alias -Name "Join-AzStorageAccountForAuth" -Value "Join-AzStorageAccount"
 function Expand-AzResourceId {
     <#
     .SYNOPSIS


### PR DESCRIPTION
- Fix name too long bug:
    - Implemented the ADObjectNameOverride parameter for Join-AzStorageAccountForAuth.
    - If no override is specified and the storage account is longer than 15 characters, truncate the storage account name to the first 10, and generate 5 random characters to append as a suffix. 
- Remove #requires header in favor of installing the modules onload. This reuses some code from the old module, however, I've added ShouldProcess support so the installation isn't just silent.
- Install Az.Storage 1.11.1-preview by default, but move forward with 1.8.1-preview if it's already installed.
- Check if SPN already exists and through and error if it doesn't.
- Add specify OU by distinguished name. The issue was not with nested OUs, but rather with OUs names that have multiple matches.
- Add an alias for `Join-AzStorageAccount` for `Join-AzStorageAccountForAuth`