### PR TITLE
Additional bug fixes and feedback

### DIFF
--- a/HybridManagement/HybridManagement.psd1
+++ b/HybridManagement/HybridManagement.psd1
@@ -80,19 +80,23 @@
         "Get-OSFeature",
         "Install-OSFeature",
         "Request-OSFeature",
+        "Get-RandomString",
+        "Assert-DotNetFrameworkVersion",
+
+        # Azure Files AD domain join cmdlets
         "Get-AzStorageAccountADObject",
         "Get-AzStorageKerberosTicketStatus",
         "Test-AzStorageAccountADObjectPasswordIsKerbKey",
         "Update-AzStorageAccountADObjectPassword",
         "Join-AzStorageAccount", 
         "Invoke-AzStorageAccountADObjectPasswordRotation",
+
+        # General Azure cmdlets
         "Expand-AzResourceId",
         "Compress-AzResourceId",
         "Get-AzCurrentAzureADUser",
         "Test-AzPermission",
-        "Assert-AzPermission",
-        "Get-RandomString",
-        "Assert-DotNetFrameworkVersion"
+        "Assert-AzPermission"
     
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport = @()

--- a/HybridManagement/HybridManagement.psd1
+++ b/HybridManagement/HybridManagement.psd1
@@ -91,7 +91,8 @@
         "Get-AzCurrentAzureADUser",
         "Test-AzPermission",
         "Assert-AzPermission",
-        "Get-RandomString"
+        "Get-RandomString",
+        "Assert-DotNetFrameworkVersion"
     
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport = @()

--- a/HybridManagement/HybridManagement.psm1
+++ b/HybridManagement/HybridManagement.psm1
@@ -819,14 +819,30 @@ function Request-AzPowerShellModule {
             }
 
             if ($null -eq $storageModule) {
+                Remove-Module `
+                        -Name Az.Storage `
+                        -Force `
+                        -ErrorAction SilentlyContinue
+                
+                try {
+                    Uninstall-Module `
+                            -Name Az.Storage `
+                            -Force `
+                            -ErrorAction Stop
+                } catch {
+                    Write-Error `
+                            -Message "Unable to uninstall the GA version of the Az.Storage module in favor of the preview version (1.11.1-preview)." `
+                            -ErrorAction Stop
+                }
+
                 Install-Module `
-                    -Name Az.Storage `
-                    -AllowClobber `
-                    -AllowPrerelease `
-                    -Force `
-                    -RequiredVersion "1.11.1-preview" `
-                    -SkipPublisherCheck `
-                    -ErrorAction Stop
+                        -Name Az.Storage `
+                        -AllowClobber `
+                        -AllowPrerelease `
+                        -Force `
+                        -RequiredVersion "1.11.1-preview" `
+                        -SkipPublisherCheck `
+                        -ErrorAction Stop
             }       
         }
     }


### PR DESCRIPTION
This PR adds the following:
- Added explicit .NET Framework check for .NET Framework 4.7.1, as this required by the Az module on PowerShell 5.1. This slightly improves the error message we give - the Az message was pretty good.
- Go back to attempting uninstall of Az.Storage GA module. I was trying to avoid this, because it's a large source of module load issues, but Adam was seeing weird issues with what modules go loaded (which is why he was asking for us to auto-load Az.Accounts).
- Add commentary from Yuemin about what's in the module. 